### PR TITLE
Do not require items when creating shopcart

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -1,7 +1,7 @@
 """
 My Service
 
-ShopCart APIs 
+ShopCart APIs
 - Get all shop carts in the database
 
 """

--- a/service/routes.py
+++ b/service/routes.py
@@ -34,7 +34,7 @@ def index():
 
 
 ######################################################################
-#  SHOPCART   A P I   E N D P O I N T S
+#  S H O P C A R T   A P I   E N D P O I N T S
 ######################################################################
 @app.route("/shopcarts/<int:shopcart_id>", methods=["GET"])
 def get_shopcart_by_id(shopcart_id):
@@ -66,20 +66,6 @@ def create_shopcart():
 
     shopcart = Shopcart()
     shopcart.deserialize(request.get_json())
-
-    # check if no customer_id passing in the body
-    if not request.get_json()["customer_id"]:
-        return make_response(
-            "Missing customer_id in request body.", status.HTTP_400_BAD_REQUEST
-        )
-
-    # check if the customer already have a shopcart
-    shopcarts = Shopcart.find_shopcart_by_customer_id(request.get_json()["customer_id"])
-    results = [shopcart.serialize() for shopcart in shopcarts]
-    if len(results) > 0:
-        return make_response(
-            "Customer already have a shopcart", status.HTTP_400_BAD_REQUEST
-        )
 
     shopcart.create()
 
@@ -238,7 +224,9 @@ def delete_item(shopcart_id, item_id):
 
     This endpoint will delete an item based the id specified in the path
     """
-    app.logger.info("Request to delete item %s for shopcart_id: %s", item_id, shopcart_id)
+    app.logger.info(
+        "Request to delete item %s for shopcart_id: %s", item_id, shopcart_id
+    )
 
     # See if the item exists and delete it if it does
     item = CartItem.find(item_id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -310,7 +310,8 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(shopcarts, [])
 
         shopcart = ShopcartFactory()
-        [CartItemFactory(shopcart=shopcart) for _ in range(3)]
+        for _ in range(3):
+            CartItemFactory(shopcart=shopcart)
         shopcart.create()
         # Assert that it was assigned an id and shows up in the database
         self.assertIsNotNone(shopcart.id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,9 +52,13 @@ class TestShopcart(unittest.TestCase):
     def test_create_a_shopcart(self):
         """It should Create a Shopcart and assert that it exists"""
         fake_shopcart = ShopcartFactory()
-        shopcart = Shopcart(items=fake_shopcart.items)
+        shopcart = Shopcart(
+            id=fake_shopcart.id,
+            customer_id=fake_shopcart.customer_id,
+            items=fake_shopcart.items,
+        )
         self.assertIsNotNone(shopcart)
-        self.assertEqual(shopcart.id, None)
+        self.assertEqual(shopcart.id, fake_shopcart.id)
 
     def test_add_a_shopcart(self):
         """It should Create a Shopcart and add it to the database"""
@@ -63,7 +67,7 @@ class TestShopcart(unittest.TestCase):
 
         shopcart = ShopcartFactory()
         shopcart.create()
-        # # Assert that it was assigned an ID and shows up in the database
+        # Assert that it was assigned an ID and shows up in the database
         self.assertIsNotNone(shopcart.id)
         shopcarts = Shopcart.all()
         self.assertEqual(len(shopcarts), 1)
@@ -88,6 +92,23 @@ class TestShopcart(unittest.TestCase):
         found_shopcart = Shopcart.find(shopcart.id)
         self.assertEqual(found_shopcart.id, shopcart.id)
         self.assertEqual(found_shopcart.items, [])
+
+    def test_update_shopcart(self):
+        """It should update a Shopcart"""
+        shopcart = ShopcartFactory()
+        shopcart.create()
+
+        # Read it back
+        found_shopcart = Shopcart.find(shopcart.id)
+        self.assertEqual(found_shopcart.id, shopcart.id)
+
+        # Update field
+        shopcart.customer_id = 123
+        shopcart.update()
+
+        # Read back updated shopcart
+        found_shopcart = Shopcart.find(shopcart.id)
+        self.assertEqual(found_shopcart.customer_id, 123)
 
     def test_delete_a_shopcart(self):
         """It should Delete a shopcart from the database"""
@@ -157,6 +178,15 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(
             new_shopcart.items[0].product_name, shopcart.items[0].product_name
         )
+
+    def test_deserialize_a_shopcart_no_items(self):
+        """It should Deserialize a Shopcart"""
+        shopcart = ShopcartFactory()
+        shopcart.create()
+        serialized_shopcart = shopcart.serialize()
+        new_shopcart = Shopcart()
+        new_shopcart.deserialize(serialized_shopcart)
+        self.assertEqual(len(new_shopcart.items), len(shopcart.items))
 
     def test_deserialize_cart_item(self):
         """It should Deserialize a Cart Item"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -148,9 +148,9 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(data[0]["customer_id"], shopcarts[1].customer_id)
 
     # Note: need further check
-    def test_get_shopcarts_by_customer_id_404NotFound(self):
+    def test_get_shopcarts_by_customer_id_404(self):
         """It should return 404 not found by given a non-existed customer id"""
-        shopcarts = self._create_shopcarts(3)
+        self._create_shopcarts(3)
         resp = self.client.get(BASE_URL, query_string=f"customer_id={4}")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
@@ -476,7 +476,6 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(data["error"], "Bad Request")
         self.assertIn("Quantity must be a positive integer", data["message"])
 
-
     def test_update_shopcart(self):
         """It should update a shopcart and assert that it has changed"""
         shopcarts = Shopcart.all()
@@ -484,7 +483,8 @@ class TestYourResourceServer(TestCase):
 
         shopcart = ShopcartFactory()
         # Populate Shopcart with 3 CartItems
-        [CartItemFactory(shopcart=shopcart) for _ in range(3)]
+        for _ in range(3):
+            CartItemFactory(shopcart=shopcart)
         shopcart.create()
 
         shopcart = Shopcart.find(shopcart.id)


### PR DESCRIPTION
Succesfull postman request to `POST /shopcarts` with only `customer_id` in the body and no `items`.
![Screenshot 2023-10-29 at 9 13 53 PM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/a8b1e781-c484-4a9a-aacb-2f714662c305)


Tests passing & over 95% coverage in models
![Screenshot 2023-10-29 at 9 13 23 PM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/376c2b14-5868-40e1-b6e3-8986f3bbac2a)
