### PR TITLE
Delete item from shopcart always returns 204. Create duplicate shopcart returns 409

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -18,7 +18,7 @@
 Module: error_handlers
 """
 from flask import jsonify
-from service.models import DataValidationError
+from service.models import DataValidationError, DataConflictError
 from service import app
 from . import status
 
@@ -30,6 +30,12 @@ from . import status
 def request_validation_error(error):
     """Handles Value Errors from bad data"""
     return bad_request(error)
+
+
+@app.errorhandler(DataConflictError)
+def data_conflict_error(error):
+    """Handles conflict errors from create requests"""
+    return resource_conflict(error)
 
 
 @app.errorhandler(status.HTTP_400_BAD_REQUEST)

--- a/service/routes.py
+++ b/service/routes.py
@@ -230,11 +230,7 @@ def delete_item(shopcart_id, item_id):
     # note: if shopcart not exist, do nothing
     if item:
         item.delete()
-    else:
-        abort(
-            status.HTTP_404_NOT_FOUND,
-            f"Item with id '{item_id}' could not be found.",
-        )
+
     return make_response("", status.HTTP_204_NO_CONTENT)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,13 @@ import os
 import logging
 import unittest
 from service import app
-from service.models import Shopcart, CartItem, DataValidationError, db
+from service.models import (
+    Shopcart,
+    CartItem,
+    DataValidationError,
+    DataConflictError,
+    db,
+)
 from tests.factories import ShopcartFactory, CartItemFactory
 
 DATABASE_URI = os.getenv(
@@ -81,7 +87,7 @@ class TestShopcart(unittest.TestCase):
         shopcart.create()
         shopcart2 = ShopcartFactory()
         shopcart2.customer_id = shopcart.customer_id
-        self.assertRaises(DataValidationError, shopcart2.create)
+        self.assertRaises(DataConflictError, shopcart2.create)
 
     def test_read_shopcart(self):
         """It should Read a Shopcart"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -103,15 +103,15 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
     def test_create_shopcart_with_empty_body(self):
-        """It should get a 400 bad request response"""
+        """It should get a 400 bad request response for an empty body"""
         resp = self.client.post(BASE_URL, json={})
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_shopcart_having_existed_shopcart(self):
-        """It should get a 400 bad request response"""
+        """It should get a 409 conflict error for duplicate customer_id"""
         shopcart = self._create_shopcarts(1)
         resp = self.client.post(BASE_URL, json={"customer_id": shopcart[0].customer_id})
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
 
     def test_get_shopcarts_list(self):
         """It should get a list of shopcarts created"""
@@ -349,7 +349,7 @@ class TestYourResourceServer(TestCase):
             f"{BASE_URL}/{shop_cart.id}/items/{item_id}",
             content_type="application/json",
         )
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_update_item_quantity_shopcart_not_found(self):
         """It should return a 404 NOT FOUND response when the shopcart is not found"""


### PR DESCRIPTION
This fixes 2 bugs where:

1. Deleting a non-existent item from shopcart was returning a 404. The correct RESTful response should always be a 209.
2. Creating a Shopcart with a customer_id that already exists was returning 400. The correct RESTful response should be 409.

![Screenshot 2023-11-01 at 11 12 07 AM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/ef16b483-0a58-45ce-806e-f81e994f17ca)

![Screenshot 2023-11-01 at 11 03 19 AM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/2c085a4f-fa2c-4509-b937-1879b2d97833)

![Screenshot 2023-11-01 at 11 12 28 AM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/92120e42-ceb6-4672-a396-31019a208649)