### PR TITLE
Change CartItem to use product_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ delete_shopcarts   DELETE   /shopcarts/<int:shopcart_id>
 list_cart_items    GET      /shopcarts/<int:shopcart_id>/items
 create_cart_items  POST     /shopcarts/<int:shopcart_id>/items
 get_cart_items     GET      /???/<???>/???/<???>
-update_cart_items  PUT      /shopcarts/<int:shopcart_id>/items/<string:product_name>
+update_cart_items  PUT      /shopcarts/<int:shopcart_id>/items/<int:product_id>
 clear_items_in_cart  PUT   /shopcarts/<int:shopcart_id>/items/clear
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You should be able to reach the service at: http://localhost:8000. The port that
 | ----------- | --------------------- | --------------- |
 | id | Unique ID for the item. | uuid         |
 | shopcart_id | ID of the shopcart it belongs to | uuid       |
-| product_name | Name of the product | string       |
+| product_id | ID of the product | uuid       |
 | quantity | Quantity of the product in the cart | Number       |
 | price | Price of the product when it was added | Float       |
 

--- a/service/models.py
+++ b/service/models.py
@@ -124,7 +124,7 @@ class CartItem(db.Model, PersistentBase):
 
     def create(self):
         """
-        Creates a Shopcart to the database
+        Creates a CartItem in the database
         """
         try:
             logger.info("Creating %s", self.product_id)
@@ -137,13 +137,13 @@ class CartItem(db.Model, PersistentBase):
 
     def update(self):
         """
-        Updates a Shopcart to the database
+        Updates a CartItem in the database
         """
         logger.info("Updating %s", self.product_id)
         db.session.commit()
 
     def delete(self):
-        """Removes a Shopcart from the data store"""
+        """Removes a CartItem from the database"""
         logger.info("Deleting %s", self.product_id)
         db.session.delete(self)
         db.session.commit()

--- a/service/models.py
+++ b/service/models.py
@@ -7,7 +7,7 @@ import logging
 from abc import abstractmethod
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import IntegrityError
-from psycopg2.errors import UniqueViolation, NotNullViolation
+from psycopg2.errors import UniqueViolation
 
 logger = logging.getLogger("flask.app")
 

--- a/service/models.py
+++ b/service/models.py
@@ -7,7 +7,7 @@ import logging
 from abc import abstractmethod
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import IntegrityError
-from psycopg2.errors import UniqueViolation
+from psycopg2.errors import UniqueViolation, NotNullViolation
 
 logger = logging.getLogger("flask.app")
 
@@ -126,9 +126,12 @@ class CartItem(db.Model, PersistentBase):
         """
         Creates a CartItem in the database
         """
-        logger.info("Creating %s", self.product_id)
-        db.session.add(self)
-        db.session.commit()
+        try:
+            logger.info("Creating %s", self.product_id)
+            db.session.add(self)
+            db.session.commit()
+        except IntegrityError as error:
+            raise DataValidationError("Invalid CartItem: " + error.args[0]) from error
 
     def update(self):
         """

--- a/service/models.py
+++ b/service/models.py
@@ -126,14 +126,9 @@ class CartItem(db.Model, PersistentBase):
         """
         Creates a CartItem in the database
         """
-        try:
-            logger.info("Creating %s", self.product_id)
-            db.session.add(self)
-            db.session.commit()
-        except KeyError as error:
-            raise DataValidationError(
-                "Invalid CartItem: missing " + error.args[0]
-            ) from error
+        logger.info("Creating %s", self.product_id)
+        db.session.add(self)
+        db.session.commit()
 
     def update(self):
         """

--- a/service/models.py
+++ b/service/models.py
@@ -109,26 +109,50 @@ class CartItem(db.Model, PersistentBase):
     """
 
     # Table Schema
-    id = db.Column(db.Integer, primary_key=True)
     shopcart_id = db.Column(
         db.Integer, db.ForeignKey("shopcart.id", ondelete="CASCADE"), nullable=False
     )
-    product_name = db.Column(db.String(64), nullable=False)
+    product_id = db.Column(db.Integer, primary_key=True)
     quantity = db.Column(db.Integer, nullable=False)
-    price = db.Column(db.Float())
+    price = db.Column(db.Float(), nullable=False)
 
     def __repr__(self):
-        return f"<CartItem {self.product_name} id=[{self.id}] shopcart[{self.shopcart_id}]>"
+        return f"<CartItem id=[{self.product_id}] shopcart[{self.shopcart_id}]>"
 
     def __str__(self):
-        return f"{self.product_name}: Price={self.price}, Quantity={self.quantity}"
+        return f"{self.product_id}: Price={self.price}, Quantity={self.quantity}"
+
+    def create(self):
+        """
+        Creates a Shopcart to the database
+        """
+        try:
+            logger.info("Creating %s", self.product_id)
+            db.session.add(self)
+            db.session.commit()
+        except KeyError as error:
+            raise DataValidationError(
+                "Invalid CartItem: missing " + error.args[0]
+            ) from error
+
+    def update(self):
+        """
+        Updates a Shopcart to the database
+        """
+        logger.info("Updating %s", self.product_id)
+        db.session.commit()
+
+    def delete(self):
+        """Removes a Shopcart from the data store"""
+        logger.info("Deleting %s", self.product_id)
+        db.session.delete(self)
+        db.session.commit()
 
     def serialize(self) -> dict:
         """Converts a CartItem into a dictionary"""
         return {
-            "id": self.id,
             "shopcart_id": self.shopcart_id,
-            "product_name": self.product_name,
+            "product_id": self.product_id,
             "quantity": self.quantity,
             "price": self.price,
         }
@@ -142,7 +166,7 @@ class CartItem(db.Model, PersistentBase):
         """
         try:
             self.shopcart_id = data["shopcart_id"]
-            self.product_name = data["product_name"]
+            self.product_id = data["product_id"]
             self.price = data["price"]
             self.quantity = data["quantity"]
         except KeyError as error:
@@ -157,21 +181,21 @@ class CartItem(db.Model, PersistentBase):
         return self
 
     @classmethod
-    def find_cart_item_by_shopcart_id_and_product_name(cls, shopcart_id, product_name):
+    def find_cart_item_by_shopcart_id_and_product_id(cls, shopcart_id, product_id):
         """Returns shopcart with the given customer_id
 
         Args:
             shopcart_id (Integer): the id of the customer you want to match
-            product_name (String): the name of the product you want to match
+            product_id (Integer): the id of the product you want to match
         """
         logger.info(
-            "Processing shopcart_id and product_name query for %s and %s ...",
+            "Processing shopcart_id and product_id query for %s and %s ...",
             shopcart_id,
-            product_name,
+            product_id,
         )
         return (
             cls.query.filter(cls.shopcart_id == shopcart_id)
-            .filter(cls.product_name == product_name)
+            .filter(cls.product_id == product_id)
             .all()
         )
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -55,11 +55,8 @@ class CartItemFactory(factory.Factory):
 
         model = CartItem
 
-    id = factory.Sequence(lambda n: n)
+    product_id = factory.Sequence(lambda n: n)
     shopcart_id = None
-    product_name = FuzzyChoice(
-        choices=["iPhone", "iPad", "MacBook", "Google Pixel", "Apple Watch"]
-    )
     quantity = FuzzyInteger(1, 10)
     price = FuzzyFloat(0.1, 51.0)
     shopcart = factory.SubFactory(ShopcartFactory)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,7 @@
 Test Factory to make fake objects for testing
 """
 import factory
-from factory.fuzzy import FuzzyChoice, FuzzyFloat, FuzzyInteger
+from factory.fuzzy import FuzzyFloat, FuzzyInteger
 from service.models import Shopcart, CartItem
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ import logging
 import unittest
 from service import app
 from service.models import (
+    PersistentBase,
     Shopcart,
     CartItem,
     DataValidationError,
@@ -54,6 +55,11 @@ class TestShopcart(unittest.TestCase):
     ######################################################################
     #  T E S T   C A S E S
     ######################################################################
+
+    def test_persistent_base_init(self):
+        """PersistentBase id should initially be none"""
+        obj = PersistentBase()
+        self.assertIsNone(obj.id, "id should initially be none")
 
     def test_create_a_shopcart(self):
         """It should Create a Shopcart and assert that it exists"""
@@ -160,9 +166,8 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(serialized_shopcart["id"], shopcart.id)
         self.assertEqual(len(serialized_shopcart["items"]), 1)
         items = serialized_shopcart["items"]
-        self.assertEqual(items[0]["id"], cart_item.id)
         self.assertEqual(items[0]["shopcart_id"], cart_item.shopcart_id)
-        self.assertEqual(items[0]["product_name"], cart_item.product_name)
+        self.assertEqual(items[0]["product_id"], cart_item.product_id)
         self.assertEqual(items[0]["quantity"], cart_item.quantity)
         self.assertEqual(items[0]["price"], cart_item.price)
 
@@ -180,9 +185,7 @@ class TestShopcart(unittest.TestCase):
         )
         self.assertEqual(new_shopcart.items[0].price, shopcart.items[0].price)
         self.assertEqual(new_shopcart.items[0].quantity, shopcart.items[0].quantity)
-        self.assertEqual(
-            new_shopcart.items[0].product_name, shopcart.items[0].product_name
-        )
+        self.assertEqual(new_shopcart.items[0].product_id, shopcart.items[0].product_id)
 
     def test_deserialize_a_shopcart_no_items(self):
         """It should Deserialize a Shopcart"""
@@ -201,7 +204,7 @@ class TestShopcart(unittest.TestCase):
         new_cart_item = CartItem()
         new_cart_item.deserialize(serialized_cart_item)
         self.assertEqual(new_cart_item.shopcart_id, cart_item.shopcart_id)
-        self.assertEqual(new_cart_item.product_name, cart_item.product_name)
+        self.assertEqual(new_cart_item.product_id, cart_item.product_id)
         self.assertEqual(new_cart_item.quantity, cart_item.quantity)
         self.assertEqual(new_cart_item.price, cart_item.price)
 
@@ -239,7 +242,7 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(len(shopcarts), 1)
 
         new_shopcart = Shopcart.find(shopcart.id)
-        self.assertEqual(new_shopcart.items[0].product_name, cart_item.product_name)
+        self.assertEqual(new_shopcart.items[0].product_id, cart_item.product_id)
 
         cart_item2 = CartItemFactory(shopcart=shopcart)
         shopcart.items.append(cart_item2)
@@ -247,7 +250,7 @@ class TestShopcart(unittest.TestCase):
 
         new_shopcart = Shopcart.find(shopcart.id)
         self.assertEqual(len(new_shopcart.items), 2)
-        self.assertEqual(new_shopcart.items[1].product_name, cart_item2.product_name)
+        self.assertEqual(new_shopcart.items[1].product_id, cart_item2.product_id)
 
     def test_update_account_address(self):
         """It should Update a Shopcarts cart item"""
@@ -276,7 +279,7 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(address.quantity, 36)
 
     def test_delete_shopcart_cart_item(self):
-        """It should Delete an accounts address"""
+        """It should Delete a Shopcarts CartItem"""
         shopcarts = Shopcart.all()
         self.assertEqual(shopcarts, [])
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -111,6 +111,11 @@ class TestShopcart(unittest.TestCase):
         shopcart2.customer_id = shopcart.customer_id
         self.assertRaises(DataConflictError, shopcart2.create)
 
+    def test_add_item_with_key_error(self):
+        """It should raise an error if key is missing while creating item"""
+        cart_item = CartItem()
+        self.assertRaises(DataValidationError, cart_item.create)
+
     def test_read_shopcart(self):
         """It should Read a Shopcart"""
         shopcart = ShopcartFactory()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,6 +61,23 @@ class TestShopcart(unittest.TestCase):
         obj = PersistentBase()
         self.assertIsNone(obj.id, "id should initially be none")
 
+    def test_models_repr_str(self):
+        """Shopcart and CartItem repr and str should be correct"""
+        shopcart = Shopcart()
+        cart_item = CartItem()
+        self.assertEqual(
+            shopcart.__repr__(),  # pylint: disable=unnecessary-dunder-call
+            f"<ShopCart id=[{shopcart.id}] customer_id=[{shopcart.customer_id}]>",
+        )
+        self.assertEqual(
+            cart_item.__repr__(),  # pylint: disable=unnecessary-dunder-call
+            f"<CartItem id=[{cart_item.product_id}] shopcart[{cart_item.shopcart_id}]>",
+        )
+        self.assertEqual(
+            cart_item.__str__(),  # pylint: disable=unnecessary-dunder-call
+            f"{cart_item.product_id}: Price={cart_item.price}, Quantity={cart_item.quantity}",
+        )
+
     def test_create_a_shopcart(self):
         """It should Create a Shopcart and assert that it exists"""
         fake_shopcart = ShopcartFactory()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -314,6 +314,15 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         resp = self.client.get(f"{BASE_URL}/{shop_cart.id + 1}/items")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_add_cart_item_without_product_id(self):
+        """It should get a 400 bad request if cart item is added without product id"""
+        # add two items to the shopcart
+        shop_cart = self._create_shopcarts(1)[0]
+        # Create an item from cart item factory
+        cart_item = {"shopcart_id": 1, "quantity": 1, "price": 1.0}
+        resp = self.client.post(f"{BASE_URL}/{shop_cart.id}/items", json=cart_item)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_delete_item_with_existing_item(self):
         """It should Delete an item from a customers shopcart"""
         shop_cart = self._create_shopcarts(1)[0]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -178,7 +178,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
     ######################################################################
 
     def test_add_cart_item(self):
-        """It should Add an cart item to a shopcart"""
+        """It should add a CartItem to a ShopCart"""
         shop_cart = self._create_shopcarts(1)[0]
         cart_item = CartItemFactory()
         resp = self.client.post(
@@ -190,7 +190,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         data = resp.get_json()
         logging.debug(data)
         self.assertEqual(data["shopcart_id"], shop_cart.id)
-        self.assertEqual(data["product_name"], cart_item.product_name)
+        self.assertEqual(data["product_id"], cart_item.product_id)
         self.assertEqual(data["quantity"], cart_item.quantity)
         self.assertEqual(data["price"], cart_item.price)
 
@@ -202,7 +202,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         # Remove the quantity from the cart_item
         cart_item_data = {
             "shopcart_id": cart_item.shopcart_id,
-            "product_name": cart_item.product_name,
+            "product_id": cart_item.product_id,
             "price": cart_item.price,
         }
 
@@ -215,7 +215,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         data = resp.get_json()
         logging.debug(data)
         self.assertEqual(data["shopcart_id"], shop_cart.id)
-        self.assertEqual(data["product_name"], cart_item.product_name)
+        self.assertEqual(data["product_id"], cart_item.product_id)
 
         # Assert that the quantity defaults to 1
         self.assertEqual(data["quantity"], 1)
@@ -234,7 +234,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         data = resp.get_json()
         logging.debug(data)
         self.assertEqual(data["shopcart_id"], shop_cart.id)
-        self.assertEqual(data["product_name"], cart_item.product_name)
+        self.assertEqual(data["product_id"], cart_item.product_id)
         self.assertEqual(data["quantity"], cart_item.quantity)
         self.assertEqual(data["price"], cart_item.price)
 
@@ -272,7 +272,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         # Create the second item by modifying the first one to ensure their difference
         cart_item2_data = {
             "shopcart_id": cart_item1.shopcart_id,
-            "product_name": cart_item1.product_name + "No.2",
+            "product_id": cart_item1.product_id + 1,
             "price": cart_item1.price,
         }
         resp = self.client.post(
@@ -302,7 +302,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         # Create the second item by modifying the first one to ensure their difference
         cart_item2_data = {
             "shopcart_id": cart_item1.shopcart_id,
-            "product_name": cart_item1.product_name + "No.2",
+            "product_id": cart_item1.product_id + 1,
             "price": cart_item1.price,
         }
         resp = self.client.post(
@@ -320,7 +320,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         cart_item = CartItemFactory()
         cart_item_data = {
             "shopcart_id": cart_item.shopcart_id,
-            "product_name": cart_item.product_name,
+            "product_id": cart_item.product_id,
             "price": cart_item.price,
         }
 
@@ -335,7 +335,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
 
         # send delete request
         resp = self.client.delete(
-            f"{BASE_URL}/{shop_cart.id}/items/{data['id']}",
+            f"{BASE_URL}/{shop_cart.id}/items/{data['product_id']}",
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
@@ -355,10 +355,10 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         """It should return a 404 NOT FOUND response when the shopcart is not found"""
         # Update the quantity of an item in a non-existent shopcart
         non_existent_shopcart_id = 9999999
-        product_name = "NonExistentProduct"
+        product_id = 9999999
         update_data = {"quantity": 8}
         resp = self.client.put(
-            f"{BASE_URL}/{non_existent_shopcart_id}/items/{product_name}",
+            f"{BASE_URL}/{non_existent_shopcart_id}/items/{product_id}",
             json=update_data,
             content_type="application/json",
         )
@@ -372,12 +372,12 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
     def test_update_item_quantity_product_not_found(self):
         """It should return a 404 NOT FOUND response when the product is not found in the shopcart"""
         shop_cart = self._create_shopcarts(1)[0]
-        non_existent_product_name = "NonExistentProduct"
+        non_existent_product_id = 9999999
         new_quantity = 8
         # Update the quantity of a non-existent product in the shopcart
         update_data = {"quantity": new_quantity}
         resp = self.client.put(
-            f"{BASE_URL}/{shop_cart.id}/items/{non_existent_product_name}",
+            f"{BASE_URL}/{shop_cart.id}/items/{non_existent_product_id}",
             json=update_data,
             content_type="application/json",
         )
@@ -386,7 +386,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         data = resp.get_json()  # Assuming your response is in JSON format
         self.assertEqual(data["error"], "Not Found")
         self.assertIn(
-            f"Product '{non_existent_product_name}' not found in shopcart {shop_cart.id}",
+            f"Product '{non_existent_product_id}' not found in shopcart {shop_cart.id}",
             data["message"],
         )
 
@@ -406,13 +406,13 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         # Define the new quantity for the cart item
         new_quantity = 10
         # Retrieve the cart item for testing
-        cart_item_for_testing = CartItem.find_cart_item_by_shopcart_id_and_product_name(
-            shop_cart.id, cart_item.product_name
+        cart_item_for_testing = CartItem.find_cart_item_by_shopcart_id_and_product_id(
+            shop_cart.id, cart_item.product_id
         )[0]
         # Update the cart item's quantity
         update_data = {"quantity": new_quantity}
         resp = self.client.put(
-            f"{BASE_URL}/{shop_cart.id}/items/{cart_item.product_name}",
+            f"{BASE_URL}/{shop_cart.id}/items/{cart_item.product_id}",
             json=update_data,
             content_type="application/json",
         )
@@ -423,7 +423,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         # Verify the response contains the updated quantity
         self.assertEqual(
             data["log"],
-            f"Quantity of '{cart_item.product_name}' in shopcart {shop_cart.id} updated to {new_quantity}",
+            f"Quantity of '{cart_item.product_id}' in shopcart {shop_cart.id} updated to {new_quantity}",
         )
         # Verify the cart item's quantity is updated
         self.assertEqual(cart_item_for_testing.quantity, new_quantity)
@@ -442,7 +442,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         negative_quantity = -88
         update_data = {"quantity": negative_quantity}
         resp = self.client.put(
-            f"{BASE_URL}/{shop_cart.id}/items/{cart_item.product_name}",
+            f"{BASE_URL}/{shop_cart.id}/items/{cart_item.product_id}",
             json=update_data,
             content_type="application/json",
         )
@@ -466,7 +466,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         decimal_quantity = 8.8
         update_data = {"quantity": decimal_quantity}
         resp = self.client.put(
-            f"{BASE_URL}/{shop_cart.id}/items/{cart_item.product_name}",
+            f"{BASE_URL}/{shop_cart.id}/items/{cart_item.product_id}",
             json=update_data,
             content_type="application/json",
         )
@@ -507,10 +507,10 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
 
         # NOTE: The primary keys are auto generated so don't compare them
         self.assertEqual(len(data["items"]), len(new_items))
-        req_items = sorted(data["items"], key=lambda k: k["product_name"])
-        new_items = sorted(new_items, key=lambda k: k["product_name"])
+        req_items = sorted(data["items"], key=lambda k: k["product_id"])
+        new_items = sorted(new_items, key=lambda k: k["product_id"])
         for i in range(len(data["items"])):
-            self.assertEqual(req_items[i]["product_name"], new_items[i]["product_name"])
+            self.assertEqual(req_items[i]["product_id"], new_items[i]["product_id"])
             self.assertEqual(req_items[i]["quantity"], new_items[i]["quantity"])
             self.assertEqual(req_items[i]["price"], new_items[i]["price"])
 
@@ -520,7 +520,7 @@ class TestYourResourceServer(TestCase):  # pylint: disable=too-many-public-metho
         cart_item = CartItemFactory()
         cart_item_data = {
             "shopcart_id": cart_item.shopcart_id,
-            "product_name": cart_item.product_name,
+            "product_id": cart_item.product_id,
             "price": cart_item.price,
         }
 


### PR DESCRIPTION
This changes the model of `CartItem` to use `product_id` instead of `product_name`.

This means the path to add/remove/get items in a cart would now be:
`/shopcarts/<shopcart_id>/items/<product_id>`

![Screenshot 2023-11-09 at 7 26 26 PM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/6ffb93f1-6a98-4be3-8379-e4452bdb1c19)
