### PR TITLE
Add openshift to install-tools

### DIFF
--- a/.devcontainer/scripts/install-tools.sh
+++ b/.devcontainer/scripts/install-tools.sh
@@ -50,5 +50,20 @@ tar xvzf tkn_0.18.0_Linux_$ARCH.tar.gz -C /usr/local/bin/ tkn
 ln -s /usr/local/bin/tkn /usr/bin/tkn
 
 echo "**********************************************************************"
+echo "Install OpenShift 4 CLI..."
+echo "**********************************************************************"
+# OpenShift CLI has platform specific installs
+if [ $ARCH == amd64 ]; then
+    echo "Installing OpenShift for Intel..."
+    curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz
+else
+    echo "Installing OpenShift for $ARCH ..."
+    curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-$ARCH.tar.gz --output oc.tar.gz
+fi;
+sudo tar xvzf oc.tar.gz -C /usr/local/bin/ oc
+sudo ln -s /usr/local/bin/oc /usr/bin/oc
+rm oc.tar.gz
+
+echo "**********************************************************************"
 echo "TOOLS INSTALLATION COMPLETE !!!"
 echo "**********************************************************************"


### PR DESCRIPTION
We can now run `oc ...` commands from command line after these changes. See below 👇 

![Screenshot 2023-12-04 at 11 21 19 PM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/58d9d217-bfe1-4831-ab55-d0c5d06a89b9)


![Screenshot 2023-12-04 at 11 22 17 PM](https://github.com/CSCI-GA-2820-FA23-003/shopcarts/assets/9358407/d667f8b6-450e-429f-ad7b-8e1f8d96da47)
