### PR TITLE
Fix python image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: python:3.11-slim
+    container: quay.io/rofrano/python:3.11-slim 
 
     # Required services    
     services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM quay.io/rofrano/python:3.11-slim 
 
 
 # Install PostgreSQL development packages


### PR DESCRIPTION
Changing `docker.io/library/python:3-11-slim` to `quay.io/rofrano/python:3.11-slim` because of rate limiting issues.